### PR TITLE
Fix redirect URL creation for leading slashes in OAuth endpoint

### DIFF
--- a/packages/open-collaboration-server/src/auth-endpoints/oauth-endpoint.ts
+++ b/packages/open-collaboration-server/src/auth-endpoints/oauth-endpoint.ts
@@ -125,7 +125,7 @@ export abstract class OAuthEndpoint implements AuthEndpoint {
 
     protected createRedirectUrl(host: string, port: number, path: string): string {
         const baseURL = this.baseURL ?? `http://${host === '0.0.0.0' ? 'localhost' : host}:${port}`;
-        return new URL(path, baseURL).toString();
+        return new URL(path.startsWith('/') ? path.substring(1) : path, baseURL).toString();
     }
 }
 


### PR DESCRIPTION
When testing out #169 I ran into an issue with my setup in which `oct` is being served using a base url (at `http://localhost/services/oct/`). The redirect URL was not correctly being constructed, ignoring the value of `OCT_BASE_URL`.

The issue seems to be that since `path` always starts with a `/`, URL construction is ignoring `basePath`'s path prefix (`/services/oct/`, in my case):

```js
>> new URL('/api/foo', 'http://localhost/service/oct/').toString();
"http://localhost/api/foo" 
>> new URL('api/foo', 'http://localhost/service/oct/').toString();
"http://localhost/service/oct/api/foo" 
```
