### PR TITLE
Reject inactive auth methods

### DIFF
--- a/packages/open-collaboration-server/src/auth-endpoints/auth-endpoint.ts
+++ b/packages/open-collaboration-server/src/auth-endpoints/auth-endpoint.ts
@@ -21,4 +21,5 @@ export interface AuthEndpoint {
     onStart(app: Express, hostname: string, port: number): void;
     onDidAuthenticate: Event<AuthSuccessEvent>;
     getProtocolProvider(): AuthProvider;
+    isProvider(providerName: string): boolean;
 }

--- a/packages/open-collaboration-server/src/auth-endpoints/auth-endpoint.ts
+++ b/packages/open-collaboration-server/src/auth-endpoints/auth-endpoint.ts
@@ -21,5 +21,5 @@ export interface AuthEndpoint {
     onStart(app: Express, hostname: string, port: number): void;
     onDidAuthenticate: Event<AuthSuccessEvent>;
     getProtocolProvider(): AuthProvider;
-    isProvider(providerName: string): boolean;
+    getName(): string;
 }

--- a/packages/open-collaboration-server/src/auth-endpoints/authentik-endpoint.ts
+++ b/packages/open-collaboration-server/src/auth-endpoints/authentik-endpoint.ts
@@ -75,10 +75,9 @@ export class AuthentikOAuthEndpoint extends OAuthEndpoint {
 
     }
 
-    override isProvider(providerName: string): boolean {
-        return providerName === this.label;
+    override getName(): string {
+        return this.label;
     }
-
 }
 
 type AuthentikStrategyOptions = OAuth2Strategy.StrategyOptions & {

--- a/packages/open-collaboration-server/src/auth-endpoints/authentik-endpoint.ts
+++ b/packages/open-collaboration-server/src/auth-endpoints/authentik-endpoint.ts
@@ -75,6 +75,10 @@ export class AuthentikOAuthEndpoint extends OAuthEndpoint {
 
     }
 
+    override isProvider(providerName: string): boolean {
+        return providerName === this.label;
+    }
+
 }
 
 type AuthentikStrategyOptions = OAuth2Strategy.StrategyOptions & {

--- a/packages/open-collaboration-server/src/auth-endpoints/generic-oauth-endpoint.ts
+++ b/packages/open-collaboration-server/src/auth-endpoints/generic-oauth-endpoint.ts
@@ -77,10 +77,9 @@ export class GenericOAuthEndpoint extends OAuthEndpoint {
         return this.userInfoUrl ? new OIDCStrategy(options, verify) : new OAuth2Strategy(options, verify);
     }
 
-    override isProvider(providerName: string): boolean {
-        return providerName === this.label;
+    override getName(): string {
+        return this.label;
     }
-
 }
 
 export type ODICOptions = OAuth2Strategy.StrategyOptions & {

--- a/packages/open-collaboration-server/src/auth-endpoints/generic-oauth-endpoint.ts
+++ b/packages/open-collaboration-server/src/auth-endpoints/generic-oauth-endpoint.ts
@@ -77,6 +77,10 @@ export class GenericOAuthEndpoint extends OAuthEndpoint {
         return this.userInfoUrl ? new OIDCStrategy(options, verify) : new OAuth2Strategy(options, verify);
     }
 
+    override isProvider(providerName: string): boolean {
+        return providerName === this.label;
+    }
+
 }
 
 export type ODICOptions = OAuth2Strategy.StrategyOptions & {

--- a/packages/open-collaboration-server/src/auth-endpoints/keycloak-endpoint.ts
+++ b/packages/open-collaboration-server/src/auth-endpoints/keycloak-endpoint.ts
@@ -78,7 +78,10 @@ export class KeycloakOAuthEndpoint extends OAuthEndpoint {
             };
             done(undefined, userInfo);
         });
+    }
 
+    override isProvider(providerName: string): boolean {
+        return providerName === this.label;
     }
 
 }

--- a/packages/open-collaboration-server/src/auth-endpoints/keycloak-endpoint.ts
+++ b/packages/open-collaboration-server/src/auth-endpoints/keycloak-endpoint.ts
@@ -80,9 +80,8 @@ export class KeycloakOAuthEndpoint extends OAuthEndpoint {
         });
     }
 
-    override isProvider(providerName: string): boolean {
-        return providerName === this.label;
+    override getName(): string {
+        return this.label;
     }
-
 }
 

--- a/packages/open-collaboration-server/src/auth-endpoints/oauth-endpoint.ts
+++ b/packages/open-collaboration-server/src/auth-endpoints/oauth-endpoint.ts
@@ -127,6 +127,8 @@ export abstract class OAuthEndpoint implements AuthEndpoint {
         const baseURL = this.baseURL ?? `http://${host === '0.0.0.0' ? 'localhost' : host}:${port}`;
         return new URL(path.startsWith('/') ? path.substring(1) : path, baseURL).toString();
     }
+
+    abstract isProvider(providerName: string): boolean;
 }
 
 @injectable()
@@ -166,6 +168,10 @@ export class GitHubOAuthEndpoint extends OAuthEndpoint {
             };
             done(undefined, userInfo);
         });
+    }
+
+    override isProvider(providerName: string): boolean {
+        return providerName === 'GitHub';
     }
 }
 
@@ -207,5 +213,9 @@ export class GoogleOAuthEndpoint extends OAuthEndpoint {
             };
             done(undefined, userInfo);
         });
+    }
+
+    override isProvider(providerName: string): boolean {
+        return providerName === 'Google';
     }
 }

--- a/packages/open-collaboration-server/src/auth-endpoints/oauth-endpoint.ts
+++ b/packages/open-collaboration-server/src/auth-endpoints/oauth-endpoint.ts
@@ -128,7 +128,7 @@ export abstract class OAuthEndpoint implements AuthEndpoint {
         return new URL(path.startsWith('/') ? path.substring(1) : path, baseURL).toString();
     }
 
-    abstract isProvider(providerName: string): boolean;
+    abstract getName(): string;
 }
 
 @injectable()
@@ -164,14 +164,14 @@ export class GitHubOAuthEndpoint extends OAuthEndpoint {
             const userInfo: UserInfo = {
                 name: profile.displayName,
                 email: profile.emails?.[0]?.value,
-                authProvider: 'Github'
+                authProvider: this.getName()
             };
             done(undefined, userInfo);
         });
     }
 
-    override isProvider(providerName: string): boolean {
-        return providerName === 'GitHub';
+    override getName(): string {
+        return 'GitHub';
     }
 }
 
@@ -209,13 +209,13 @@ export class GoogleOAuthEndpoint extends OAuthEndpoint {
             const userInfo: UserInfo = {
                 name: profile.displayName,
                 email: profile.emails?.find(mail => mail.verified)?.value,
-                authProvider: 'Google'
+                authProvider: this.getName()
             };
             done(undefined, userInfo);
         });
     }
 
-    override isProvider(providerName: string): boolean {
-        return providerName === 'Google';
+    override getName(): string {
+        return 'Google';
     }
 }

--- a/packages/open-collaboration-server/src/auth-endpoints/simple-login-endpoint.ts
+++ b/packages/open-collaboration-server/src/auth-endpoints/simple-login-endpoint.ts
@@ -85,7 +85,7 @@ export class SimpleLoginEndpoint implements AuthEndpoint {
                 const token = req.body.token as string;
                 const user = req.body.user as string;
                 const email = req.body.email as string | undefined;
-                await Promise.all(this.authSuccessEmitter.fire({ token, userInfo: { name: user, email, authProvider: 'Unverified' } }));
+                await Promise.all(this.authSuccessEmitter.fire({ token, userInfo: { name: user, email, authProvider: this.getName() } }));
                 res.send('Ok');
             } catch (err) {
                 this.logger.error('Failed to perform simple login', err);
@@ -95,7 +95,7 @@ export class SimpleLoginEndpoint implements AuthEndpoint {
         });
     }
 
-    isProvider(providerName: string): boolean {
-        return providerName === 'Unverified';
+    getName(): string {
+        return 'Unverified';
     }
 }

--- a/packages/open-collaboration-server/src/auth-endpoints/simple-login-endpoint.ts
+++ b/packages/open-collaboration-server/src/auth-endpoints/simple-login-endpoint.ts
@@ -94,4 +94,8 @@ export class SimpleLoginEndpoint implements AuthEndpoint {
             }
         });
     }
+
+    isProvider(providerName: string): boolean {
+        return providerName === 'Unverified';
+    }
 }

--- a/packages/open-collaboration-server/src/collaboration-server.ts
+++ b/packages/open-collaboration-server/src/collaboration-server.ts
@@ -165,6 +165,15 @@ export class CollaborationServer {
         const auth = (req.headers['x-oct-jwt'] ?? req.cookies?.['oct-jwt']) as string;
         try {
             const user = await this.credentials.getUser(auth);
+            // Confirm that the provider used for authentication is still active
+            if (user) {
+                const provider = user.authProvider;
+                const found = this.authEndpoints.find(endpoint => endpoint.shouldActivate() && endpoint.isProvider(provider));
+                if (!found) {
+                    // Provider is no longer active
+                    return undefined;
+                }
+            }
             return user;
         } catch {
             return undefined;

--- a/packages/open-collaboration-server/src/collaboration-server.ts
+++ b/packages/open-collaboration-server/src/collaboration-server.ts
@@ -63,6 +63,8 @@ export class CollaborationServer {
     @multiInject(AuthEndpoint)
     protected readonly authEndpoints: AuthEndpoint[];
 
+    protected readonly activeAuthProviders = new Set<string>();
+
     startServer(opts: CollaborationServerOptions): void {
         this.logger.debug('Starting Open Collaboration Server ...');
 
@@ -120,6 +122,7 @@ export class CollaborationServer {
                         throw new Error('Failed to confirm user');
                     }
                 });
+                this.activeAuthProviders.add(authEndpoint.getName());
             }
         }
 
@@ -168,8 +171,7 @@ export class CollaborationServer {
             // Confirm that the provider used for authentication is still active
             if (user) {
                 const provider = user.authProvider;
-                const found = this.authEndpoints.find(endpoint => endpoint.shouldActivate() && endpoint.isProvider(provider));
-                if (!found) {
+                if (!this.activeAuthProviders.has(provider)) {
                     // Provider is no longer active
                     return undefined;
                 }

--- a/packages/open-collaboration-server/src/room-manager.ts
+++ b/packages/open-collaboration-server/src/room-manager.ts
@@ -73,7 +73,8 @@ export class RoomManager {
             user: {
                 id: user.id,
                 name: user.name,
-                email: user.email
+                email: user.email,
+                authProvider: user.authProvider
             },
             host: true,
             roomClock: 0

--- a/packages/open-collaboration-server/src/types.ts
+++ b/packages/open-collaboration-server/src/types.ts
@@ -31,7 +31,7 @@ export interface User {
     id: string;
     name: string;
     email?: string;
-    authProvider?: string;
+    authProvider: string;
 }
 
 export function isUser(obj: unknown): obj is User {


### PR DESCRIPTION
This change ensures that users that are using an auth method that is no longer available (i.e. has been deactivated) will not successfully authenticate with the server. Instead, they will be prompted to login again.